### PR TITLE
Use correct schema node definition, Fixes #8

### DIFF
--- a/lib/absinthe_auth/middleware.ex
+++ b/lib/absinthe_auth/middleware.ex
@@ -41,7 +41,7 @@ defmodule AbsintheAuth.Middleware do
         resolution
 
       [] ->
-        field = String.to_atom(definition.name)
+        field = definition.schema_node.identifier
 
         # Insert default middleware
         push_middleware(resolution, {Absinthe.Middleware.MapGet, field})

--- a/test/absinthe_auth_test.exs
+++ b/test/absinthe_auth_test.exs
@@ -10,6 +10,7 @@ defmodule AbsintheAuthTest do
       movie(id: $id) {
         title
         budget
+        boxOffice
       }
     }
   """
@@ -20,6 +21,7 @@ defmodule AbsintheAuthTest do
       |> Absinthe.run(Schema, variables: %{"id" => 1})
       |> assert_success
       |> assert_field_error(["movie", "budget"], "Denied")
+      |> assert_field_error(["movie", "boxOffice"], "Denied")
     end
 
     test "movie title is visible" do
@@ -46,6 +48,7 @@ defmodule AbsintheAuthTest do
       |> Absinthe.run(Schema, variables: %{"id" => 1}, context: context)
       |> assert_success
       |> assert_field(["movie", "budget"], 63_000_000)
+      |> assert_field(["movie", "boxOffice"], 463_000_000)
       |> assert_field(["movie", "title"], "The Matrix")
     end
   end

--- a/test/support/movies/database.ex
+++ b/test/support/movies/database.ex
@@ -3,11 +3,46 @@ defmodule Movies.Database do
 
   def get_movies do
     [
-      %Movie{id: 1, title: "The Matrix", budget: 63_000_000, producer_id: "producer", released: true},
-      %Movie{id: 2, title: "Star Wars", budget: 11_000_000, producer_id: 200, released: true},
-      %Movie{id: 3, title: "Gone with the Wind", budget: 4_000_000, producer_id: 300, released: true},
-      %Movie{id: 4, title: "Clueless", budget: 12_000_000, producer_id: 400, released: true},
-      %Movie{id: 5, title: "Avatar 23", budget: 100_000_000, producer_id: "producer", released: false},
+      %Movie{
+        id: 1,
+        title: "The Matrix",
+        budget: 63_000_000,
+        box_office: 463_000_000,
+        producer_id: "producer",
+        released: true
+      },
+      %Movie{
+        id: 2,
+        title: "Star Wars",
+        budget: 11_000_000,
+        box_office: 1_600_000_000,
+        producer_id: 200,
+        released: true
+      },
+      %Movie{
+        id: 3,
+        title: "Gone with the Wind",
+        budget: 4_000_000,
+        box_office: 1_800_000_000,
+        producer_id: 300,
+        released: true
+      },
+      %Movie{
+        id: 4,
+        title: "Clueless",
+        budget: 12_000_000,
+        box_office: 56_000_000,
+        producer_id: 400,
+        released: true
+      },
+      %Movie{
+        id: 5,
+        title: "Avatar 23",
+        budget: 100_000_000,
+        box_office: 0,
+        producer_id: "producer",
+        released: false
+      },
     ]
   end
 

--- a/test/support/movies/movie.ex
+++ b/test/support/movies/movie.ex
@@ -1,3 +1,10 @@
 defmodule Movies.Movie do
-  defstruct [:id, :title, :budget, :producer_id, :released]
+  defstruct [
+    :id,
+    :title,
+    :budget,
+    :box_office,
+    :producer_id,
+    :released
+  ]
 end

--- a/test/support/movies/schema.ex
+++ b/test/support/movies/schema.ex
@@ -59,10 +59,19 @@ defmodule Movies.Schema do
   object :movie do
     field :id, non_null(:id)
     field :title, :string
+
+    @desc "The movie's budget"
     field :budget, :integer do
       policy Permit, :producer
       policy Permit, :studio_manager
     end
+
+    @desc "How much the movie made at the box office"
+    field :box_office, :integer do
+      policy Permit, :producer
+      policy Permit, :studio_manager
+    end
+
     field :genre, :genre do
       resolve fn _, _ ->
         {:ok, %{}} # TODO


### PR DESCRIPTION
When injecting the default middleware (`MapGet`) the field name needs to be the internal schema node identifier and not the field name in the query. This is particularly important when the [camelcase document adapter](https://hexdocs.pm/absinthe/Absinthe.Adapter.LanguageConventions.html) is used and the field names in the query may not match the internal identifier.