### PR TITLE
Play nice with other middleware for default fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,14 @@ jobs:
       - image: circleci/elixir:1.6
 
     working_directory: ~/repo
+    environment:
+      MIX_ENV: test
     steps:
       - checkout
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
-      - run: mix do compile --warnings-as-errors, coveralls.json
+      - run: MIX_ENV=test mix do compile --warnings-as-errors, coveralls.json
       - run:
           name: Running Inch CI documentation tests
           command: |

--- a/test/support/movies/schema.ex
+++ b/test/support/movies/schema.ex
@@ -83,4 +83,14 @@ defmodule Movies.Schema do
     field :id, non_null(:id)
     field :name, non_null(:string)
   end
+
+  # These middleware do nothing but help test absinthe_auth for the case where
+  # there are other middleware at play.
+  def do_nothing(resolution, _) do
+    resolution
+  end
+
+  def middleware(middleware, _, _) do
+    middleware ++ [{{__MODULE__, :do_nothing}, []}]
+  end
 end


### PR DESCRIPTION
It appears that `absinthe` doesn't like it when you add middleware to a field and will strip the default middleware, which meant for `absinthe_auth` to try to push default middleware back in. The first commit in this PR demonstrates about seven of the fourteen tests failing because we've added a `noop` middleware: this is because `absinthe_auth` is assuming that it should only add default middleware back in if there is no other middleware to be processed. 

This patch should rectify that by checking if the `Absinthe.Resolution` or default middleware are present down the line. If the middleware in the resolution is empty or if either of those aren't present we jam in the middleware. Thankfully, the default middleware is idempotent on resolved resolutions, so this shouldn't cause problems if we add it later to the middleware, although there still may be the case of _others_ doing wonky things to the middleware like how we are doing.

Ideally, we shouldn't even be thinking about this. We should be performing the authorisation and letting the resolution go on it's way if there's nothing for us to resolve. I will try to raise an issue on `absinthe` to see if this can be resolved upstream.